### PR TITLE
Fix account already exists when generic error occurs

### DIFF
--- a/app/app/src/main/java/com/example/clubwat/viewmodels/SignUpViewModel.kt
+++ b/app/app/src/main/java/com/example/clubwat/viewmodels/SignUpViewModel.kt
@@ -60,21 +60,13 @@ class SignUpViewModel(private val userRepository: UserRepository) : ViewModel() 
 
                     OutputStreamWriter(outputStream).use { it.write(body) }
                     emailSent = responseCode == HttpURLConnection.HTTP_OK
-                    if (emailSent) {
-                        val response = inputStream.bufferedReader().use { it.readText() }
-                        val jsonResponse = JSONObject(response)
-                        val token = jsonResponse.optString("data", null.toString())
-                        userRepository.setUserId(token)
-
-                        println("Response: $response")
-                    } else {
+                    if (!emailSent) {
                         val response = errorStream.bufferedReader().use { it.readText() }
                         allValuesError.value = "This account already exists"
                         println("Error Response: $response")
                     }
                 }
             } catch (e: Exception) {
-                allValuesError.value = "This account already exists"
                 e.printStackTrace()
             }
             withContext(Dispatchers.Main) {

--- a/timelog.md
+++ b/timelog.md
@@ -55,4 +55,4 @@
 | 02/25/2024 | 1.2    |        |        |         |         |         | Get my clubs endpoint                                    |
 | 02/28/2024 |        |        |        |         |         | 5       | Completed most of the frontend work for browsing events  |
 | 02/29/2024 |        |        |        |         |         | 1       | Full stack work to complete all of event browsing        |
-| 02/29/2024 | 1      |        |        |         |         |         | Handle user already exists and tries to register error   |
+| 02/29/2024 | 1.1    |        |        |         |         |         | Handle user already exists and tries to register error   |


### PR DESCRIPTION
- caused by errors being thrown by trying to convert the string to a json object
- login and registration still works since this endpoint doesn't send a token back