### PR TITLE
fix default create_date for notifications

### DIFF
--- a/app/app/src/main/java/com/example/clubwat/viewmodels/InboxViewModel.kt
+++ b/app/app/src/main/java/com/example/clubwat/viewmodels/InboxViewModel.kt
@@ -29,7 +29,7 @@ class InboxViewModel(private val userRepository: UserRepository) : ViewModel() {
                 val responseCode = con.responseCode
                 println("Response Code :: $responseCode")
                 if (responseCode == HttpURLConnection.HTTP_OK) {
-                    _notifications.value = _notifications.value.filter { it.id != id }.toMutableList()
+                    getNotifications()
                 }
             } catch (e: Exception) {
                 e.printStackTrace()

--- a/app/app/src/main/java/com/example/clubwat/views/ClubDetailsView.kt
+++ b/app/app/src/main/java/com/example/clubwat/views/ClubDetailsView.kt
@@ -1,5 +1,6 @@
 package com.example.clubwat.views
 
+import DetailItem
 import android.annotation.SuppressLint
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -23,6 +24,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ExitToApp
 import androidx.compose.material.icons.automirrored.filled.Send
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.AttachMoney
 import androidx.compose.material.icons.filled.Cancel
 import androidx.compose.material.icons.filled.ChatBubble
 import androidx.compose.material.icons.filled.Settings
@@ -57,6 +59,8 @@ import com.example.clubwat.model.EventWrapper
 import com.example.clubwat.ui.theme.LightOrange
 import com.example.clubwat.ui.theme.LightYellow
 import com.example.clubwat.viewmodels.ClubDetailsViewModel
+import java.text.NumberFormat
+import java.util.Currency
 
 @OptIn(ExperimentalLayoutApi::class)
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
@@ -169,6 +173,14 @@ fun ClubDetailsView(
                         showClubDetailsView = true
                 })
                 Spacer(modifier = Modifier.height(16.dp))
+                if (club != null) {
+                    val format = NumberFormat.getNumberInstance()
+                    format.minimumFractionDigits = 2
+                    format.maximumFractionDigits = 2
+                    DetailItem(text = format.format(club!!.membershipFee), icon = Icons.Filled.AttachMoney)
+                }
+                Spacer(modifier = Modifier.height(16.dp))
+
                 Column(modifier = Modifier.fillMaxWidth(),
                     horizontalAlignment = Alignment.CenterHorizontally) {
                     Text(fontWeight = FontWeight.Bold,

--- a/server/prisma/migrations/20240311190725_/migration.sql
+++ b/server/prisma/migrations/20240311190725_/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Notification" ALTER COLUMN "create_date" SET DEFAULT NOW();

--- a/server/prisma/migrations/20240311191159_/migration.sql
+++ b/server/prisma/migrations/20240311191159_/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Notification" ALTER COLUMN "create_date" DROP DEFAULT;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -167,7 +167,7 @@ model Notification {
   club_id             Int?
   event_id            Int?
   content             String
-  create_date         DateTime @default(dbgenerated("NOW()"))
+  create_date         DateTime
   source_user         User   @relation(name: "source_user", fields: [source_user_id], references: [id])
   destination_user    User   @relation(name: "destination_user", fields: [destination_user_id], references: [id])
   club                Club?  @relation(fields: [club_id], references: [id])

--- a/server/src/api/ClubAdminRoutes.ts
+++ b/server/src/api/ClubAdminRoutes.ts
@@ -101,6 +101,7 @@ router.put(
       data: {
         destination_user_id: targetUserId,
         club_id: clubId,
+        create_date: new Date(),
         content: `Membership approved for ${member.club.title}`,
         source_user_id: req.body.user.id,
       },

--- a/server/src/api/ShareRoutes.ts
+++ b/server/src/api/ShareRoutes.ts
@@ -41,6 +41,7 @@ router.put("/club", authenticateToken, async (req, res) => {
       source_user_id: sourceUser.id,
       destination_user_id: destinationUserId,
       club_id: clubId,
+      create_date: new Date(),
       content: `${sharedClub.title} was shared with you!`,
     },
   });
@@ -77,6 +78,7 @@ router.put("/event", authenticateToken, async (req, res) => {
       source_user_id: sourceUser.id,
       destination_user_id: destinationUserId,
       event_id: eventId,
+      create_date: new Date(),
       content: `${sharedEvent.title} was shared with you!`,
     },
   });

--- a/timelog.md
+++ b/timelog.md
@@ -80,3 +80,4 @@
 | 03/11/2024 |        |        |        |         | 2       |         | User Friendship Endpoints review + fixes according to UI    |
 | 03/10/2024 |        |        | 0.5    |         |         |         | Reviewed Frontend PRs                                       |
 | 03/10/2024 |        |        | 5.5    |         |         |         | Worked on For You Page                                      |
+| 03/10/2024 | 1      |        |        |         |         |         | Bug fix for notifications, membership fee in club details   |


### PR DESCRIPTION
it worked but was creating an annoying amount of migrations, removed the default and just manually specifying it.